### PR TITLE
constraint issues

### DIFF
--- a/lib/postgres.js
+++ b/lib/postgres.js
@@ -22,6 +22,7 @@ var Postgres = function(connection){
          information_schema.table_constraints tc  \
       where                                       \
         cu.constraint_name = tc.constraint_name   \
+        and tc.constraint_type = 'PRIMARY KEY'    \
       and tc.table_name = ist.table_name          \
     ) as pk                                       \
     from information_schema.tables ist            \


### PR DESCRIPTION
This fix here is just an update to the sql script for postgresql to pull in the table names with primary keys. This doesn't address the issue for composite primary keys though. It seems either the recommendation would be to not use them, which seems less than ideal, or to change the way these arguments are composed and parsed.
