### PR TITLE
Fix for multiple results from subquery

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -19,6 +19,7 @@ var MySQL = function(credentials){
       select column_name from                       \
       information_schema.key_column_usage           \
       where table_name = ist.table_name             \
+      and constraint_schema = ist.table_schema      \
       and constraint_name = 'PRIMARY'               \
     )  as 'pk'                                      \
     from information_schema.tables ist              \


### PR DESCRIPTION
If the table name is the same between multiple schemas, multiple
results get returned from the subquery which causes the query to fail.
