### PR TITLE
Fix inner query returning more than one result

### DIFF
--- a/lib/mysql.js
+++ b/lib/mysql.js
@@ -20,7 +20,7 @@ var MySQL = function(credentials){
       information_schema.key_column_usage           \
       where table_name = ist.table_name             \
       and constraint_schema = ist.table_schema      \
-      and constraint_name = 'PRIMARY'               \
+      and constraint_name = 'PRIMARY' LIMIT 1       \
     )  as 'pk'                                      \
     from information_schema.tables ist              \
     where table_schema = '" + credentials.database + "'";


### PR DESCRIPTION
On **MySQL**, only the first table was being exposed in the database object after connecting to the database.

The inner query returned more than one result, causing the external query to return only one table (the first one). Adding `LIMIT 1` to the inner query fixes this issue.
