### PR TITLE
(untested) Upgrade deasync package for compatibility with Node v4

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "async": "^0.9.0",
     "clone": "^1.0.2",
     "commander": "^2.6.0",
-    "deasync": "^0.0.10",
+    "deasync": "^0.1.1",
     "glob": "^4.4.1",
     "pg": "^4.3.0",
     "pg-query-stream": "^0.7.0",


### PR DESCRIPTION
Upgraded to Node v4 and started getting build errors relating to deasync. Upgrading deasync package  seemed to fix it. I ran `npm test` but apparently the tests don't work this way. I don't have time to figure out how the tests work right now...maybe somebody with a working test suite can try it out real quick?
