### PR TITLE
Add error handling to initial connection in repl

### DIFF
--- a/bin/massive.js
+++ b/bin/massive.js
@@ -24,6 +24,10 @@ if(program.database){
 
 if(connectionString){
   massive.connect({connectionString : connectionString}, function(err,db){ 
+    if(err) {
+      console.log("Failed loading Massive: "+err);
+      process.exit(1);
+    }
     var context = repl.start({
       prompt: "db > ",
     }).context;


### PR DESCRIPTION
My repl failed silently when trying to connect to a remote Heroku database because the default database URL doesn't not force SSL which is required when connecting from outside Heroku. This change at least forces an error.
