### PR TITLE
length property insert bug fixed

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -36,7 +36,7 @@ Table.prototype.insert = function(data, next) {
   var fn = function() { return "$" + (++seed); };
 
   for(var i = 0, seed = 0; i < data.length; ++i) {
-    var v = _.map(data[i], fn);
+    var v = _.map(Object.keys(data[i]), fn);
     values.push(util.format('(%s)', v.join(', ')));
     parameters.push(_.values(data[i]));
   }


### PR DESCRIPTION
Due to how underscore lib works, `_.each`, `_.map` ... methods have problems iterating objects containing a "length" property. (https://github.com/jashkenas/underscore/issues/2407)

For example this insert query fails with a `INSERT has more expressions than target columns` error:

```
massive.table.insert([{
  name: 'foo',
  length: 123
}, {
  name: 'bar',
  length: 456
}]);
```

Iterating object keys array instead of the object fixes the problem for insert.

I didn't try the update method but I'm guessing the same thing happens there too as the object is iterated by `_.each`. I'm not sure if this was done intentionally for some reason, so I wanted to check with you first.
