### PR TITLE
Connection wrapper - e.g. to allow row level security

### DIFF
--- a/index.js
+++ b/index.js
@@ -187,12 +187,10 @@ Massive.prototype.initialize = function(resources) {
       }
     });
     for (var name in queries.children) {
-      if (rootObject[name]) {
-        self.warn("Refusing to overwrite property '" + queryPath + name + "' (" + queries.path + ")");
-      } else {
+      if (!rootObject[name]) {
         rootObject[name] = {};
-        addQueries(rootObject[name], queryPath + name + '/', queries.children[name]);
       }
+      addQueries(rootObject[name], queryPath + name + '/', queries.children[name]);
     }
   }
   addQueries(self, '', resources.queries);

--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ if (typeof Promise == 'undefined') {
 
 var Massive = function(args) {
   this._options = args;
+  if (typeof args.warn === 'function') {
+    this.warn = args.warn;
+  }
   this.scriptsDir = args.scripts || process.cwd() + "/db";
   this.enhancedFunctions = args.enhancedFunctions || false;
 
@@ -172,7 +175,7 @@ Massive.prototype.initialize = function(resources) {
       // unfortunately we can't use MapToNamespace here without making a ton of changes
       // since we need to accommodate deeply-nested directories rather than 1-deep schemata
       if (rootObject[name]) {
-        console.error("[Massive] Refusing to overwrite property '" + queryPath + name + "' (" + queries.path + ")");
+        self.warn("Refusing to overwrite property '" + queryPath + name + "' (" + queries.path + ")");
       } else {
         var _exec = new Executable(_.extend({}, spec, {
           db : self
@@ -185,7 +188,7 @@ Massive.prototype.initialize = function(resources) {
     });
     for (var name in queries.children) {
       if (rootObject[name]) {
-        console.error("[Massive] Refusing to overwrite property '" + queryPath + name + "' (" + queries.path + ")");
+        self.warn("Refusing to overwrite property '" + queryPath + name + "' (" + queries.path + ")");
       } else {
         rootObject[name] = {};
         addQueries(rootObject[name], queryPath + name + '/', queries.children[name]);
@@ -546,6 +549,11 @@ Massive.prototype.bootstrap = function(next) {
       });
     });
   });
+};
+
+// Can be over-ridden via `warn` connection setting
+Massive.prototype.warn = function (message) {
+  console.warn("[Massive] WARNING: " + message); // eslint-disable-line no-console
 };
 
 //connects Massive to the DB

--- a/index.js
+++ b/index.js
@@ -9,14 +9,14 @@ var ArgTypes = require("./lib/arg_types");
 var path = require("path");
 var DA = require('deasync');
 var stripBom = require('strip-bom');
-
-var self;
+var async = require('async');
 
 if (typeof Promise == 'undefined') {
   global.Promise = require('promise-polyfill');
 }
 
 var Massive = function(args) {
+  this._options = args;
   this.scriptsDir = args.scripts || process.cwd() + "/db";
   this.enhancedFunctions = args.enhancedFunctions || false;
 
@@ -91,14 +91,113 @@ Massive.prototype.run = function(){
 };
 Massive.prototype.runSync = DA(Massive.prototype.run);
 
-Massive.prototype.loadQueries = function() {
-  walkSqlFiles(this, this.scriptsDir);
+Massive.prototype.fetchQueries = function(next) {
+  walkSqlFiles(this, this.scriptsDir, next);
 };
 
-Massive.prototype.loadTables = function(next) {
+Massive.prototype.initialize = function(resources) {
+  var self = this;
+  self._resources = resources;
+
+  _.each(resources.tables, function(table){
+    var _table = new Table({
+      schema : table.schema,
+      name : table.name,
+      pk : table.pk,
+      db : self
+    });
+
+    MapToNamespace(_table);
+  });
+  _.each(resources.descendantTables, function (table) {
+    // if parent table is already defined it means it has been whitelisted / validated
+    // so we safely can add the descendant to the available tables
+    if (undefined !== typeof self[table.parent]) {
+      var _table = new Table({
+        schema : table.schema,
+        name : table.child,
+        pk : self[table.parent].pk,
+        db : self
+      });
+
+      MapToNamespace(_table);
+    }
+  });
+  _.each(resources.views, function(view) {
+    var _view = new Queryable({
+      schema : view.schema,
+      name : view.name,
+      db : self
+    });
+
+    MapToNamespace(_view, "views");
+  });
+  _.each(resources.functions, function(fn) {
+    var schema = fn.schema;
+    var sql;
+    var params = [];
+
+    for (var i = 1; i <= fn.param_count; i++) {
+      params.push("$" + i);
+    }
+
+    if (schema !== "public") {
+      sql = util.format("select * from \"%s\".\"%s\"", schema, fn.name);
+      self[schema] = self[schema] || {};
+    } else {
+      sql = util.format("select * from \"%s\"", fn.name);
+    }
+
+    sql += "(" + params.join(",") + ")";
+
+    var _exec = new Executable({
+      sql: sql,
+      schema: schema,
+      name : fn.name,
+      db : self,
+      singleRow: self.enhancedFunctions && fn.return_single_row,
+      singleValue: self.enhancedFunctions && fn.return_single_value
+    });
+
+    MapToNamespace(_exec, "functions");
+  });
+
+  // queries is a nested structure that takes the form:
+  // {self: [{sql, filePath, name}, {...}, ...], children: {name: {self: [{...}, {...}, ...
+  function addQueries(rootObject, queryPath, queries) {
+    queries.self.forEach(function(spec) {
+      // spec takes the form: {sql, filePath, name}
+      var name = spec.name;
+
+      // unfortunately we can't use MapToNamespace here without making a ton of changes
+      // since we need to accommodate deeply-nested directories rather than 1-deep schemata
+      if (rootObject[name]) {
+        console.error("[Massive] Refusing to overwrite property '" + queryPath + name + "' (" + queries.path + ")");
+      } else {
+        var _exec = new Executable(_.extend({}, spec, {
+          db : self
+        }));
+        self.queryFiles.push(_exec);
+        rootObject[name] = function () {
+          return _exec.invoke.apply(_exec, arguments);
+        };
+      }
+    });
+    for (var name in queries.children) {
+      if (rootObject[name]) {
+        console.error("[Massive] Refusing to overwrite property '" + queryPath + name + "' (" + queries.path + ")");
+      } else {
+        rootObject[name] = {};
+        addQueries(rootObject[name], queryPath + name + '/', queries.children[name]);
+      }
+    }
+  }
+  addQueries(self, '', resources.queries);
+};
+
+Massive.prototype.fetchTables = function(next) {
   var tableSql = __dirname + "/lib/scripts/tables.sql";
   var parameters = [this.allowedSchemas, this.blacklist, this.exceptions];
-  var self = this;
 
   // ONLY allow whitelisted items:
   if(this.whitelist) {
@@ -106,70 +205,21 @@ Massive.prototype.loadTables = function(next) {
     parameters = [this.whitelist];
   }
 
-  this.executeSqlFile({file : tableSql, params: parameters}, function(err, tables) {
-    if (err) { return next(err, null); }
-
-    _.each(tables, function(table){
-      var _table = new Table({
-        schema : table.schema,
-        name : table.name,
-        pk : table.pk,
-        db : self
-      });
-
-      MapToNamespace(_table);
-    });
-
-    next(null,self);
-  });
+  this.executeSqlFile({file : tableSql, params: parameters}, next);
 };
 
-Massive.prototype.loadDescendantTables = function(next) {
+Massive.prototype.fetchDescendantTables = function(next) {
   var tableSql = __dirname + "/lib/scripts/descendant_tables.sql";
   var parameters = [this.allowedSchemas, this.blacklist, this.exceptions];
-  var self = this;
 
-  this.executeSqlFile({file : tableSql, params: parameters}, function(err, descendantTables) {
-    if (err) { return next(err, null); }
-
-    _.each(descendantTables, function (table) {
-      // if parent table is already defined it means it has been whitelisted / validated
-      // so we safely can add the descendant to the available tables
-      if (undefined !== typeof self[table.parent]) {
-        var _table = new Table({
-          schema : table.schema,
-          name : table.child,
-          pk : self[table.parent].pk,
-          db : self
-        });
-
-        MapToNamespace(_table);
-      }
-    });
-
-    next(null, self);
-  });
+  this.executeSqlFile({file : tableSql, params: parameters}, next);
 };
 
-Massive.prototype.loadViews = function(next) {
+Massive.prototype.fetchViews = function(next) {
   var viewSql = __dirname + "/lib/scripts/views.sql";
   var parameters = [this.allowedSchemas, this.blacklist, this.exceptions];
 
-  this.executeSqlFile({file : viewSql, params: parameters}, function(err, views){
-    if (err) { return next(err, null); }
-
-    _.each(views, function(view) {
-      var _view = new Queryable({
-        schema : view.schema,
-        name : view.name,
-        db : self
-      });
-
-      MapToNamespace(_view, "views");
-    });
-
-    next(null, self);
-  });
+  this.executeSqlFile({file : viewSql, params: parameters}, next);
 };
 
 Massive.prototype.saveDoc = function(collection, doc, next){
@@ -177,6 +227,7 @@ Massive.prototype.saveDoc = function(collection, doc, next){
   var schemaName = "public";
   var tableName = collection;
   var potentialTable = null;
+  var self = this;
 
     // is the collection namespace delimited?
   var splits = collection.split(".");
@@ -271,6 +322,16 @@ var RemoveFromNamespace = function(db, table) {
       return element.name && element.schema && element.schema === schemaName && element.name === tableName;
     });
   }
+
+  var tableIndex = -1;
+  db._resources.tables.forEach(function(spec, index) {
+    if (spec.schema === schemaName && spec.name === tableName) {
+      tableIndex = index;
+    }
+  });
+  if (tableIndex >= 0) {
+    db._resources.tables.splice(tableIndex, 1);
+  }
 };
 
 
@@ -279,6 +340,7 @@ Massive.prototype.createDocumentTable = function(path, next) {
   var splits = path.split(".");
   var tableName;
   var schemaName;
+  var self = this;
   if(splits.length > 1) {
     // uh oh. Someone specified a schema name:
     schemaName = splits[0];
@@ -319,6 +381,7 @@ Massive.prototype.documentTableSql = function(tableName){
 
 Massive.prototype.dropTable = function(table, options, next) {
   var sql = this.dropTableSql(table, options);
+  var self = this;
   this.query(sql, function(err, res) {
     if(err) {
       next(err, null);
@@ -339,6 +402,7 @@ Massive.prototype.dropTableSql = function(tableName, options){
 
 Massive.prototype.createSchema = function(schemaName, next) {
   var sql = this.createSchemaSql(schemaName);
+  var self = this;
   this.query(sql, function(err, res) {
     if(err) {
       next(err);
@@ -359,6 +423,7 @@ Massive.prototype.createSchemaSql = function(schemaName) {
 
 Massive.prototype.dropSchema = function(schemaName, options, next) {
   var sql = this.dropSchemaSql(schemaName, options);
+  var self = this;
 
   this.query(sql, function(err, res) {
     if(err) {
@@ -386,106 +451,101 @@ Massive.prototype.dropSchemaSql = function(schemaName, options) {
   return sql;
 };
 
-
-
 //A recursive directory walker that would love to be refactored
-var walkSqlFiles = function(rootObject, rootDir) {
-  var dirs;
-  try {
-    dirs = fs.readdirSync(rootDir);
-  } catch (ex) {
-     return;
+var walkSqlFiles = function(self, rootDir, next) {
+  var results = {
+    path: rootDir,
+    self: [],
+    children: {}
+  };
+  function processFile(file, next) {
+    var filePath = path.join(rootDir, file);
+    fs.stat(filePath, function(err, stats) {
+      if (err) return next();
+      var ext = path.extname(file);
+      var name = path.basename(file, ext);
+
+      if (stats.isFile() && ext === ".sql") {
+        //why yes it is! pull in the SQL
+        //remove the unicode Byte Order Mark
+        var sql = stripBom(fs.readFileSync(filePath, {encoding : "utf-8"}));
+        results.self.push({
+          sql: sql,
+          filePath: filePath,
+          name : name
+        });
+        next();
+      } else if (stats.isDirectory()) {
+        walkSqlFiles(self, filePath, function(err, childResults) {
+          if (err) return next(err);
+          results.children[name] = childResults;
+          next();
+        });
+      } else {
+        next();
+      }
+    });
   }
+  fs.readdir(rootDir, function(err, files) {
+    // Swallow errors from non-existent directories
+    if (err) return next(null, results);
 
-  //loop the directories found
-  _.each(dirs, function(item){
-    //parsing with path is a friendly way to get info about this dir or file
-    var ext = path.extname(item);
-    var name = path.basename(item, ext);
+    // Ensure clashes are deterministic; if 'foo' and 'foo.sql' both exist then
+    // 'foo.sql' should win
+    files.sort().reverse();
 
-    //is this a SQL file?
-    if (ext === ".sql") {
-      //why yes it is! Build the abspath so we can read the file
-      var filePath = path.join(rootDir,item);
-
-      //pull in the SQL - don't worry this only happens once, when
-      //massive is loaded using connect()
-      //remove the unicode Byte Order Mark
-      var sql = stripBom(fs.readFileSync(filePath, {encoding : "utf-8"}));
-
-      var _exec = new Executable({
-        sql: sql,
-        filePath: filePath,
-        name : name,
-        db : self
-      });
-
-      // unfortunately we can't use MapToNamespace here without making a ton of changes
-      // since we need to accommodate deeply-nested directories rather than 1-deep schemata
-      self.queryFiles.push(_exec);
-      rootObject[name] = function () {
-        return _exec.invoke.apply(_exec, arguments);
-      };
-    } else if (ext === '') {
-      //this is a directory so shift things and move on down
-      //set a property on our root object, then use *that*
-      //as the root in the next call
-      rootObject[name] = {};
-
-      //set the path to walk so we have a correct root directory
-      var pathToWalk = path.join(rootDir,item);
-
-      //recursive call - do it all again
-      walkSqlFiles(rootObject[name], pathToWalk);
-    }
+    // Executing in series so we don't end up with too many in parallel; plus
+    // we want clashes to be deterministic.
+    async.eachSeries(files, processFile, function(err) {
+      next(err, results);
+    });
   });
 };
 
-Massive.prototype.loadFunctions = function(next) {
+Massive.prototype.fetchFunctions = function(next) {
   if (!this.excludeFunctions) {
     var functionSql = __dirname + "/lib/scripts/functions.sql";
     var parameters = [this.functionBlacklist, this.functionWhitelist];
 
-    this.executeSqlFile({file : functionSql, params : parameters}, function (err,functions) {
-      if (err) {
-        next(err, null);
-      } else {
-        _.each(functions, function(fn) {
-          var schema = fn.schema;
-          var sql;
-          var params = [];
-
-          for (var i = 1; i <= fn.param_count; i++) {
-            params.push("$" + i);
-          }
-
-          if (schema !== "public") {
-            sql = util.format("select * from \"%s\".\"%s\"", schema, fn.name);
-            self[schema] = self[schema] || {};
-          } else {
-            sql = util.format("select * from \"%s\"", fn.name);
-          }
-
-          sql += "(" + params.join(",") + ")";
-
-          var _exec = new Executable({
-            sql: sql,
-            schema: schema,
-            name : fn.name,
-            db : self,
-            singleRow: self.enhancedFunctions && fn.return_single_row,
-            singleValue: self.enhancedFunctions && fn.return_single_value
-          });
-
-          MapToNamespace(_exec, "functions");
-        });
-
-        next(null, self);
-      }
-    });
+    this.executeSqlFile({file : functionSql, params : parameters}, next);
   } else {
-    next(null, self);
+    next(null, {});
   }
+};
+
+Massive.prototype.bootstrap = function(next) {
+
+  var self = this;
+  //load up the tables, queries, and commands
+  self.fetchTables(function(err, tables) {
+    if (err) { return next(err); }
+
+    self.fetchDescendantTables(function (err, descendantTables) {
+      if (err) { return next(err); }
+
+      self.fetchViews(function(err, views) {
+        if (err) { return next(err); }
+
+        self.fetchFunctions(function(err, functions) {
+          if (err) { return next(err); }
+
+          self.fetchQueries(function(err, queries) {
+            if (err) { return next(err); }
+
+            self.initialize({
+              tables: tables,
+              descendantTables: descendantTables,
+              views: views,
+              functions: functions,
+              queries: queries
+            });
+
+            next(null, self);
+          });
+        });
+      });
+    });
+  });
 };
 
 //connects Massive to the DB
@@ -499,28 +559,7 @@ exports.connect = function(args, next) {
 
   var massive = new Massive(args);
 
-  //load up the tables, queries, and commands
-  massive.loadTables(function(err, db) {
-    if (err) { return next(err); }
-
-    self = db;
-
-    massive.loadDescendantTables(function () {
-      if (err) { return next(err); }
-
-      massive.loadViews(function() {
-        if (err) { return next(err); }
-
-        massive.loadFunctions(function(err, db) {
-          if (err) { return next(err); }
-
-          db.loadQueries(); // synchronous
-
-          next(null, db);
-        });
-      });
-    });
-  });
+  massive.bootstrap(next);
 };
 
 exports.loadSync = DA(this.connect);

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -16,6 +16,14 @@ var DB = function(connectionString, defaults) {
   }
 };
 
+DB.prototype.connectionWrapper = function (fn) {
+  return fn;
+};
+
+DB.prototype.pgConnect = function (connectionString, next) {
+  pg.connect(connectionString, this.connectionWrapper(next));
+};
+
 DB.prototype.query = function () {
   //we expect sql, options, params and a callback
   var args = ArgTypes.queryArgs(arguments);
@@ -33,7 +41,7 @@ DB.prototype.query = function () {
   //with the pg_node driver
   if(args.params === [{}]) args.params = [];
 
-  pg.connect(this.connectionString, function (err, db, done) {
+  this.pgConnect(this.connectionString, function (err, db, done) {
     if (err) {
       done();
 
@@ -86,7 +94,7 @@ DB.prototype.stream = function () {
   //with the pg_node driver
   if(args.params === [{}]) args.params = [];
 
-  pg.connect(this.connectionString, function (err, db, done) {
+  this.pgConnect(this.connectionString, function (err, db, done) {
     if (err) {
       done();
 

--- a/test/connection_wrapper_spec.js
+++ b/test/connection_wrapper_spec.js
@@ -1,0 +1,111 @@
+var assert = require("assert");
+var helpers = require("./helpers");
+var db;
+
+describe('connectionWrapper', function () {
+  before(function(done){
+    var self = this;
+    helpers.resetDb('connection_wrapper', function(err,res){
+      db = res;
+      db.query("select current_setting('server_version_num')", function(err, res) {
+        if (err) return done(err);
+        self.enableRLSTest = parseInt(res[0].current_setting, 10) >= 90500;
+        done();
+      });
+    });
+  });
+
+  describe('row level security', function() {
+
+    function alwaysRollback(pgClient, next, done) {
+      var error = null;
+      pgClient.query('begin', function(err) {
+        error = error || err;
+        next(error, pgClient, function (err) {
+          var args = Array.prototype.slice.call(arguments);
+          pgClient.query('rollback;', function(err2) {
+            args[0] = err || err2;
+            done.apply(null, args);
+          });
+        });
+      });
+    }
+
+    function connectionWrapperForUserId(userId) {
+      if (typeof userId !== 'number') {
+        throw new Error("connectionWrapperForUserId: userId must be an integer");
+      }
+      return function (pgClient, next, done) {
+        var error = null;
+        pgClient.query('begin', function(err) {
+          error = error || err;
+          pgClient.query('set local role massive_users', function(err) {
+            error = error || err;
+            pgClient.query("select set_config('claims.user_id', $1, true)", [userId], function(err) {
+              error = error || err;
+              next(error, pgClient, function (err) {
+                var args = Array.prototype.slice.call(arguments);
+                pgClient.query(err ? 'rollback;' : 'commit;', function(err2) {
+                  args[0] = args[0] || err2;
+                  done.apply(null, args);
+                });
+              });
+            });
+          });
+        });
+      };
+    }
+
+    describe('with alwaysRollback connection wrapper', function() {
+      it('adds a product, but rolls back', function (done) {
+        db.withConnectionWrapper(alwaysRollback).products.save({name : "Gibson Les Paul", description : "Lester's brain child", price : 3500}, function(err, res){
+          assert.ifError(err);
+          assert.ok(res.id);
+          db.products.find(res.id, function(err, res) {
+            assert.ifError(err);
+            assert(!res, "Expected record not to exist (rollback)");
+            done();
+          });
+        });
+      });
+    });
+
+    describe('add RLS record - without connectionWrapper', function() {
+      it('adds a product ', function (done) {
+        if (!this.enableRLSTest) {
+          return this.skip("Skipped - PG version doesn't support RLS");
+        }
+        db.products_with_rls.save({name : "Gibson Les Paul", description : "Lester's brain child", price : 3500}, function(err, res){
+          assert.ifError(err);
+          assert.equal(res.id, 1);
+          done();
+        });
+      });
+    });
+
+    describe('add RLS record - with connection wrapper and allowed details', function() {
+      it('adds a product ', function (done) {
+        if (!this.enableRLSTest) {
+          return this.skip("Skipped - PG version doesn't support RLS");
+        }
+        db.withConnectionWrapper(connectionWrapperForUserId(1)).products_with_rls.save({name : "Gibson Les Paul", description : "Lester's brain child", price : 3500}, function(err, res){
+          assert.ifError(err);
+          assert.equal(res.id, 2);
+          done();
+        });
+      });
+    });
+
+    describe('add RLS record - with connection wrapper and forbidden details', function() {
+      it('add a product DENIED', function (done) {
+        if (!this.enableRLSTest) {
+          return this.skip("Skipped - PG version doesn't support RLS");
+        }
+        db.withConnectionWrapper(connectionWrapperForUserId(2)).products_with_rls.save({name : "Gibson Les Paul", description : "Lester's brain child", price : 3500}, function(err){
+          assert.ok(err);
+          done();
+        });
+      });
+    });
+  });
+});

--- a/test/db/inStockProducts/byPrice.sql
+++ b/test/db/inStockProducts/byPrice.sql
@@ -1,0 +1,3 @@
+select * from products
+where in_stock = true
+order by price asc;

--- a/test/db/schemata/connection_wrapper.sql
+++ b/test/db/schemata/connection_wrapper.sql
@@ -1,0 +1,41 @@
+CREATE SCHEMA IF NOT EXISTS public;
+drop role if exists massive_users;
+
+create table products(
+  id serial primary key,
+  name varchar(50) NOT NULL,
+  price decimal(10,2) default 0.00 not null,
+  description text,
+  in_stock boolean,
+  specs jsonb,
+  created_at timestamptz default now() not null,
+  tags character varying(255)[]
+);
+
+create sequence products_with_rls_id_seq;
+create table products_with_rls(
+  id int primary key default nextval('products_with_rls_id_seq'),
+  name varchar(50) NOT NULL,
+  price decimal(10,2) default 0.00 not null,
+  description text,
+  in_stock boolean,
+  specs jsonb,
+  created_at timestamptz default now() not null,
+  tags character varying(255)[]
+);
+
+create role massive_users;
+
+do $$
+begin
+  if current_setting('server_version_num')::integer >= 90500 then
+    -- Row Level Security requires postgres 9.5+
+    execute 'alter table products_with_rls enable row level security';
+    execute 'create policy products_allow_user_1 on products_with_rls to massive_users using (current_setting(''claims.user_id'')::integer = 1)';
+  end if;
+end
+$$;
+
+grant usage on schema public to massive_users;
+grant select, insert, update on products_with_rls to massive_users;
+grant usage, select on sequence products_with_rls_id_seq to massive_users;

--- a/test/query_file_spec.js
+++ b/test/query_file_spec.js
@@ -14,7 +14,10 @@ describe('Queries built from files', function () {
 
   describe('Loading of queries', function () {
     it('has an inStockProducts query attached', function () {
-      assert(db.inStockProducts, "Not there");
+      assert.equal(typeof db.inStockProducts, 'function', "Not a function");
+    });
+    it('has an inStockProducts.byPrice query attached', function () {
+      assert.equal(typeof db.inStockProducts.byPrice, 'function', "Not a function");
     });
   });
 


### PR DESCRIPTION
Fixes #291

Rebased upon #297; to see just the changes in this (and not the refactoring): https://github.com/benjie/massive-js/compare/refactor-index...connection-wrapper

The aim of this PR is to enable a new `newDb = db.withConnectionWrapper(fn)` API that allows users to do interesting things by creating a fast clone of the massive instance, but wherein each query is wrapped with custom functionality.

The functionality could be, for example:
- calling `SET LOCAL TIME ZONE 'Europe/London'` before some queries and `SET LOCAL TIME ZONE 'America/New_York'` on others
- automatically rolling back every query by wrapping it with `begin; ... rollback;`
- switching to a different role before executing a particular function
- implementing something a bit more complex, like my specific target: row level security functionality (as demonstrated by the few tests I added)

This PR is a proof-of-concept; I think it's safe to merge but we probably ought to add more tests before documenting it as a public API!

To achieve the goal of a connection wrapper, this PR does the following things:
- Uses the two-phase `connect` changes from #297 to allow spawning a new instance of massive with all connections wrapped by a wrapper function without the need to re-scan the database/filesystem
- Adds a basic test for using this with auto-rollback
- Adds a few basic tests for using this with Row Level Security (PostgreSQL 9.5+ only; skips otherwise)
