### PR TITLE
Add joins as an option.

### DIFF
--- a/lib/query.js
+++ b/lib/query.js
@@ -59,7 +59,7 @@ Query.prototype.queryOptions = function () {
 
   var sql = "";
 
-  if (joins) { sql = joins; }
+  if (joins.length > 0) { sql = joins; }
   if (this.order) { sql += " order by " + this.order; }
   if (this.offset) { sql += " offset " + this.offset; }
   if (this.limit || this.single) { sql += " limit " + (this.limit || "1"); }
@@ -67,4 +67,3 @@ Query.prototype.queryOptions = function () {
 };
 
 module.exports = Query;
-

--- a/lib/query.js
+++ b/lib/query.js
@@ -10,6 +10,7 @@ var Query = function(args, object) {
   this.offset = args.offset;
   this.limit = args.limit;
   this.stream = args.stream;
+  this.joins = args.joins;
   this.single = args.single || false;
 };
 
@@ -48,13 +49,22 @@ Query.prototype.queryOptions = function () {
     }, []).join(",");
   }
 
+  var joins = [];
+  if (_.isArray(this.joins)) {
+    _.each(this.joins, function (join) {
+      joins.push(util.format("%s", join));
+    });
+    joins = joins.join(',');
+  }
+
   var sql = "";
 
-  if (this.order) { sql = " order by " + this.order; }
+  if (joins) { sql = joins; }
+  if (this.order) { sql += " order by " + this.order; }
   if (this.offset) { sql += " offset " + this.offset; }
   if (this.limit || this.single) { sql += " limit " + (this.limit || "1"); }
-
   return sql;
 };
 
 module.exports = Query;
+


### PR DESCRIPTION
This adds a new option where you can add an array of joins that will be added to the query.

Usage like so:

`db.cars.find({}, {joins: ['inner join dealers on dealers.id = cars.dealer_id']});`

I can also add docs if needed.