### PR TITLE
explicitly using IS or IS NOT comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules
 Session.vim
 play.js
 coverage
+.vscode

--- a/docs/simple_queries.md
+++ b/docs/simple_queries.md
@@ -76,8 +76,8 @@ valid.
 * `>=` (greater than or equal): `{"price >=": 20}`
 
 #### Null values
-* `IS NULL`: `{description: null}`, `{"description =": null}`
-* `IS NOT NULL`: `{"description <>": null}`, `{"description !=": null}`, `{"description !": null}`
+* `IS NULL`: `{description: null}`, `{"description =": null}`, `{"description is": null}`
+* `IS NOT NULL`: `{"description <>": null}`, `{"description !=": null}`, `{"description !": null}`, `{"description is not": null}`
 * `IS DISTINCT FROM` (null-sensitive `<>`): `{"color is distinct from": "red"}`
 * `IS NOT DISTINCT FROM` (null-sensitive `=`): `{"color is not distinct from": "red"}`
 

--- a/lib/operations_map.js
+++ b/lib/operations_map.js
@@ -43,7 +43,9 @@ exports = module.exports = {
   '!~': {operator: '!~'},
   '~*': {operator: '~*'},
   '!~*': {operator: '!~*'},
-  // distinct
+  // comparison predicates
+  'is': {operator: 'IS'},
+  'is not': {operator: 'IS NOT'},
   'is distinct from': {operator: 'IS DISTINCT FROM'},
   'is not distinct from': {operator: 'IS NOT DISTINCT FROM'}
 };

--- a/lib/where.js
+++ b/lib/where.js
@@ -97,7 +97,7 @@ exports.parseKey = function (key) {
 exports.predicate = function (result, condition, value) {
   if (value === null) {
     //interpolate nulls directly with is/is not
-    condition.operator = condition.operator === '=' ? 'IS' : 'IS NOT';
+    condition.operator = (condition.operator === '=' || condition.operator === 'IS') ? 'IS' : 'IS NOT';
   } else if (condition.mutator || !_.isArray(value)) {
     //parameterize any non-array or mutatey values
     if (condition.mutator) { value = condition.mutator(value); }
@@ -123,9 +123,16 @@ exports.predicate = function (result, condition, value) {
 };
 
 exports.docPredicate = function (result, condition, value, conditions) {
+  //case to check if key exist or not
+  if (value === null && (condition.operator === 'IS' || condition.operator === 'IS NOT')) {
+    result.predicates.push(
+      util.format("(body ->> '%s') %s null", condition.field, condition.operator)
+    );
+  }
+
   //if we have an array of objects, this is a deep traversal
   //we'll need to use a contains query to be sure we flex the index
-  if(_.isArray(value) && _.isObject(value[0])) {
+  else if (_.isArray(value) && _.isObject(value[0])) {
     //stringify the passed-in params
     result.params.push(JSON.stringify(conditions));
     result.predicates.push(util.format("body @> $%s", result.params.length + result.offset));

--- a/test/document_query_spec.js
+++ b/test/document_query_spec.js
@@ -137,6 +137,14 @@ describe('Document queries', function () {
       });
     });
 
+    it('check if field exists with IS NOT', function (done) {
+      db.docs.findDoc({"price is not" : null}, function(err,docs){
+        assert.ifError(err);
+        assert.equal(docs.length, 3);
+        done();
+      });
+    });
+
     it('executes a contains if passed an array of objects', function (done) {
       db.docs.findDoc({studios : [{name : "Warner"}]}, function(err,docs){
         assert.ifError(err);

--- a/test/foreign_table_spec.js
+++ b/test/foreign_table_spec.js
@@ -10,8 +10,14 @@ describe('Loading entities (these tests may be slow!)', function () {
     });
   });
 
+  it('loads foreign tables', function (done) {
+      assert.ok(db.foreigntable);
+      done();
+  });
+
   it('queries foreign tables', function (done) {
     db.foreigntable.find({}, function (err, res) {
+      assert.ifError(err);
       assert.equal(res.length, 0);
 
       done();
@@ -21,6 +27,7 @@ describe('Loading entities (these tests may be slow!)', function () {
   it('sees updated information in foreign tables', function (done) {
     db.t1.insert({id: 1}, function () {
       db.foreigntable.find({}, function (err, res) {
+        assert.ifError(err);
         assert.equal(res.length, 1);
         assert.equal(res[0].id, 1);
 
@@ -33,7 +40,7 @@ describe('Loading entities (these tests may be slow!)', function () {
     db.foreigntable.save({id: 1}, function (err) {
       assert.equal(err.message, 'No primary key, use insert or update to write to this table');
 
-      return done();
+      done();
     });
   });
 
@@ -41,7 +48,7 @@ describe('Loading entities (these tests may be slow!)', function () {
     db.foreigntable.update({id: 1}, function (err) {
       assert.equal(err.message, 'No primary key, use the (criteria, updates) signature');
 
-      return done();
+      done();
     });
   });
 });

--- a/test/queryable_spec.js
+++ b/test/queryable_spec.js
@@ -180,6 +180,22 @@ describe('Queryables', function () {
         done();
       });
     });
+    it('returns products using is null', function (done) {
+      db.products.find({"tags is": null}, function(err,res){
+        assert.ifError(err);
+        assert.equal(res.length, 1);
+        assert.equal(res[0].id, 1);
+        done();
+      });
+    });
+    it('returns products using is not null', function (done) {
+      db.products.find({"id is not": null}, function(err,res){
+        assert.ifError(err);
+        assert.equal(res.length, 4);
+        assert.equal(res[0].id, 1);
+        done();
+      });
+    });
     it('returns products using distinct from', function (done) {
       db.products.find({"tags is distinct from": '{tag1,tag2}'}, function(err,res){
         assert.ifError(err);
@@ -637,9 +653,9 @@ describe('Queryables', function () {
       });
     });
     it('returns results filtered by where', function (done) {
-      db.docs.search({columns : ["body->>'description'"], term: "C:*", where: {"body->>'is_good'": 'true'}}, function(err,res){
+      db.products.search({columns : ["description"], term: "description", where: {"in_stock": true}}, function(err,res){
         assert.ifError(err);
-        assert.equal(res.length,1);
+        assert.equal(res.length, 2);
         done();
       });
     });

--- a/test/where_spec.js
+++ b/test/where_spec.js
@@ -318,6 +318,14 @@ describe('WHERE clause generation', function () {
       assert.equal(result.params.length, 0);
     });
 
+    it('should accept IS NOT explicitly', function () {
+      var condition = {quotedField: '"field"', operator: 'IS NOT'};
+      var result = where.predicate({params: [], predicates: [], offset: 0}, condition, null);
+      assert.equal(result.predicates.length, 1);
+      assert.equal(result.predicates[0], '"field" IS NOT null');
+      assert.equal(result.params.length, 0);
+    });
+
     it('should apply operation mutators', function () {
       var condition = {
         quotedField: '"field"',
@@ -348,6 +356,14 @@ describe('WHERE clause generation', function () {
   });
 
   describe('docPredicate', function () {
+    it('should create IS comparison predicate', function () {
+      var condition = {field: 'field', operator: 'IS'};
+      var result = where.docPredicate({params: [], predicates: [], offset: 0}, condition, null, {'field is': null});
+      assert.equal(result.predicates.length, 1);
+      assert.equal(result.predicates[0], '(body ->> \'field\') IS null');
+      assert.equal(result.params.length, 0);
+    });
+
     it('should build an equality predicate using the JSON contains op', function () {
       var condition = {field: 'field', operator: '='};
       var result = where.docPredicate({params: [], predicates: [], offset: 0}, condition, 'value', {field: 'value'});


### PR DESCRIPTION
It is nice to have the option to explicitly use IS/IS NOT comparison. The main reason to have that option is to distinguish between the following WHERE clause when querying documents:
1. `SELECT * FROM "docs" WHERE body @> '{"field": null}'`
2. `SELECT * FROM "docs" WHERE (body ->> 'field') IS NULL`

See below summary of changes:
- Add explicit call for IS/IS NOT in predicate (for document or not)
- Add unit testing (for IS/IS NOT null)