### PR TITLE
Add onConflictIgnore option for INSERT

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -22,14 +22,15 @@ db.tests.find({
 
 Certain SQL clauses are used with different types of query. For example, a `LIMIT` clause can only be used with a function which emits a `SELECT` such as `find` or `count`.
 
-| Option key | Use in | Description |
-|------------|--------|-------------|
-| columns    | `SELECT` | Change the `SELECT` list by specifying an array of columns to include in the resultset. |
-| limit      | `SELECT` | Set the number of rows to take. |
-| offset     | `SELECT` | Set the number of rows to skip. |
-| only       | `SELECT`, `UPDATE`, `DELETE` | Set to `true` to restrict the query to the table specified, if any others inherit from it. |
-| order      | `SELECT` | An array of strings (`['column1', 'column2 DESC']`) which is processed into an `ORDER BY` clause. |
-| orderBody  | `SELECT` | If querying a document table, set to `true` to apply `options.order` to fields in the document body rather than the table. |
+| Option key       | Use in | Description |
+|------------------|--------|-------------|
+| columns          | `SELECT` | Change the `SELECT` list by specifying an array of columns to include in the resultset. |
+| limit            | `SELECT` | Set the number of rows to take. |
+| offset           | `SELECT` | Set the number of rows to skip. |
+| only             | `SELECT`, `UPDATE`, `DELETE` | Set to `true` to restrict the query to the table specified, if any others inherit from it. |
+| order            | `SELECT` | An array of strings (`['column1', 'column2 DESC']`) which is processed into an `ORDER BY` clause. |
+| orderBody        | `SELECT` | If querying a document table, set to `true` to apply `options.order` to fields in the document body rather than the table. |
+| onConflictIgnore | `INSERT` | If the inserted data would violate a unique constraint, do nothing. |
 
 *nb. The `columns` and `order` properties allow comma-delimited string as well as array values. Take care when using raw strings since the values are interpolated directly into the emitted SQL. If user input is included in the values, you open yourself up to SQL injection attacks.*
 

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -58,8 +58,10 @@ Either version of `insert` may be passed additional options:
 db.tests.insert({
   name: 'homepage',
   version: 1,
-}, {build: true}).then(test => {
-  // builds the query without executing it
+}, {
+  onConflictIgnore: true, // add ON CONFLICT DO NOTHING to the query
+}).then(test => {
+  // the inserted row, or `null` if there was a conflict and nothing was inserted
 });
 ```
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -154,11 +154,11 @@ Massive.prototype.reload = function () {
 /**
  * Execute a query.
  *
- * @param {Select|Insert|Update|Delete|String} - One of the four statement
+ * @param {Select|Insert|Update|Delete|String} query - One of the four statement
  * objects, or a string containing a prepared SQL statement.
  * @param {Array} [params] - An array of the prepared statement parameters, if
  * applicable.
- * @param {Object} options - If using raw SQL, a subset of query options may be
+ * @param {Object} [options] - If using raw SQL, a subset of query options may be
  * applied.
  * @param {Boolean} options.document - This is a query against a document
  * table.

--- a/lib/statement/insert.js
+++ b/lib/statement/insert.js
@@ -23,6 +23,7 @@ const Insert = function (source, record, options = {}) {
   this.document = options.document;
   this.generator = options.generator;
   this.stream = options.stream;
+  this.onConflictIgnore = options.onConflictIgnore;
 
   if (_.isArray(record)) {
     this.records = record;
@@ -50,7 +51,13 @@ Insert.prototype.format = function () {
     return acc;
   }, []);
 
-  sql += `${values.map(v => '(' + v.join(', ') + ')').join(', ')} RETURNING *`;
+  sql += `${values.map(v => '(' + v.join(', ') + ')').join(', ')} `;
+
+  if (this.onConflictIgnore) {
+    sql += 'ON CONFLICT DO NOTHING ';
+  }
+
+  sql += `RETURNING *`;
 
   return sql;
 };

--- a/lib/statement/insert.js
+++ b/lib/statement/insert.js
@@ -14,6 +14,7 @@ const _ = require('lodash');
  * it.
  * @param {Boolean} [options.stream] - True to return a stream instead of a
  * resultset.
+ * @param {Boolean} [options.onConflictIgnore] - True to add ON CONFLICT DO NOTHING
  */
 const Insert = function (source, record, options = {}) {
   // TODO look into nesting a Select

--- a/test/statement/insert.js
+++ b/test/statement/insert.js
@@ -38,5 +38,12 @@ describe('Insert', function () {
       const result = new Insert(source, [{field1: 'value1', field2: 2}, {field1: 'value2', field2: 3}]);
       assert.equal(result.format(), 'INSERT INTO testsource ("field1", "field2") VALUES ($1, $2), ($3, $4) RETURNING *');
     });
+
+    it('should handle onConflictIgnore option', function () {
+      const result = new Insert(source, {field1: 'value1'}, {onConflictIgnore: true});
+      assert.equal(result.format(), 'INSERT INTO testsource ("field1") VALUES ($1) ON CONFLICT DO NOTHING RETURNING *');
+    });
+
+
   });
 });


### PR DESCRIPTION
As discussed in #425, this adds a boolean `onConflictIgnore` option to append an `ON CONFLICT DO NOTHING` clause to a generated INSERT statement. 

The `ON CONFLICT UPDATE` variant is a bit more involved so I thought I'd push this first to get some feedback.

Where should these options be documented?