### PR TITLE
pass options through from where() to select()

### DIFF
--- a/lib/queryable.js
+++ b/lib/queryable.js
@@ -222,10 +222,10 @@ Queryable.prototype.searchDoc = function(plan, options = {}) {
  * @param {Array} [params] - Prepared statement parameters.
  * @return {Promise} An array containing any query results.
  */
-Queryable.prototype.where = function(conditions, params = []) {
+Queryable.prototype.where = function(conditions, params = [], options) {
   if (!_.isArray(params) && !_.isPlainObject(params)) { params = [params]; }
 
-  const query = new Select(this, {conditions: conditions, params: params}, {});
+  const query = new Select(this, {conditions: conditions, params: params}, options);
 
   return this.db.query(query);
 };


### PR DESCRIPTION
This is to enable query options such as count and order.   Currently there is no way to specify these things manually in the where clause, because the sql generator appends a `ORDER BY ID` if there is no order specified in options. 