### PR TITLE
pg-promise update

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "glob": "^7.1.1",
     "lodash": "^4.17.4",
     "mz": "^2.6.0",
-    "pg-promise": "^6.3.5",
+    "pg-promise": "^6.3.7",
     "pg-query-stream": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Updating version of [pg-promise] to one that requires a newer [pg-minify] which no longer swallows nested multi-line comments in SQL, reporting them as errors.

[pg-promise]:https://github.com/vitaly-t/pg-promise
[pg-minify]:https://github.com/vitaly-t/pg-minify
