### PR TITLE
Updating pg-promise dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "glob": "^7.1.1",
     "lodash": "^4.17.4",
     "mz": "^2.6.0",
-    "pg-promise": "^6.4.0",
+    "pg-promise": "~6.5.0",
     "pg-query-stream": "~1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Changed pg-promise  to [~6.5.0](https://github.com/vitaly-t/pg-promise/releases/tag/v.6.5.0). Please note that use of `^` is dangerous, and shouldn't be used, as breaking changes are possible, and they shouldn't happen. See https://stackoverflow.com/questions/22343224/whats-the-difference-between-tilde-and-caret-in-package-json

I usually do not do any breaking change on a minor version number, but this time I did it because:

* [Custom Type Formatting] change is too long overdue, and it looks like version 7.x is delayed indefinitely at this point
* Very small percentage of projects actually use [Custom Type Formatting].


[Custom Type Formatting]:https://github.com/vitaly-t/pg-promise#custom-type-formatting