### PR TITLE
Move loader normalisation into Database class

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,6 @@
 'use strict';
 
 const _ = require('lodash');
-const path = require('path');
-const filters = require('./lib/util/filters');
 const Database = require('./lib/database');
 
 /**
@@ -37,13 +35,6 @@ exports = module.exports = (connection, loader = {}, driverConfig = {}) => {
   } else if (Object.keys(connection).length === 1 && (!!connection.database)) {
     connection = `postgres://localhost:5432/${connection.database}`;
   }
-
-  ['blacklist', 'whitelist', 'functionBlacklist', 'functionWhitelist', 'exceptions'].forEach(key => {
-    loader[key] = filters.entity(loader[key]);
-  });
-
-  loader.allowedSchemas = filters.schema(loader.allowedSchemas);
-  loader.scripts = loader.scripts || path.join(process.cwd(), 'db');
 
   return (new Database(connection, loader, driverConfig)).reload();
 };

--- a/lib/database.js
+++ b/lib/database.js
@@ -9,6 +9,7 @@ const Executable = require('./executable');
 const Queryable = require('./queryable');
 const Table = require('./table');
 const docify = require('./util/docify');
+const filters = require('./util/filters');
 
 /**
  * A database connection.
@@ -32,6 +33,13 @@ const docify = require('./util/docify');
  * @param {Object} [driverConfig] - A pg-promise configuration object.
  */
 const Massive = function (connection, loader = {}, driverConfig = {}) {
+  ['blacklist', 'whitelist', 'functionBlacklist', 'functionWhitelist', 'exceptions'].forEach(key => {
+    loader[key] = filters.entity(loader[key]);
+  });
+
+  loader.allowedSchemas = filters.schema(loader.allowedSchemas);
+  loader.scripts = loader.scripts || path.join(process.cwd(), 'db');
+
   this.loader = loader;
   this.driverConfig = driverConfig;
   this.pgp = pgp(driverConfig);


### PR DESCRIPTION
Opens the possibility to use the Database class directly without losing some of the loader functionality.

In the future, I plan on opening another PR where I would attempt to expose the `Database` class from `lib/database.js` as an importable entity, so that you may do:

```js
import { Database } from 'massive-js'

class massive = new Database(connection, loader, driverConfig)
// muuuch later, both in code and in time...
await massive.reload()
```

> I have a use case where I need to initialise the Database instance first and only much later do an actual database connection.