### PR TITLE
findOne({}, {single: true}) should not throw (#451)

### DIFF
--- a/lib/util/docify.js
+++ b/lib/util/docify.js
@@ -3,6 +3,10 @@
 const _ = require('lodash');
 
 function docify(row) {
+  if (row == null) {
+    return null;
+  }
+
   let returnDoc = _.cloneDeep(row.body);
 
   returnDoc.id = row.id;

--- a/test/queryable/findDoc.js
+++ b/test/queryable/findDoc.js
@@ -132,6 +132,12 @@ describe('findDoc', function () {
       });
     });
 
+    it('returns null when a single document is\'nt found', function () {
+        return db.docs.findDoc({title: 'Not Dound'}, {single: true}).then(doc => {
+            assert.equal(doc, null);
+        });
+    });
+
     it('applies criteria', function () {
       return db.docs.findDoc({title: 'Document 1'}).then(docs => {
         assert.lengthOf(docs, 1);

--- a/test/util/docify.js
+++ b/test/util/docify.js
@@ -16,7 +16,7 @@ describe('docify', function () {
     assert.deepEqual(docs, [{id: 1, val: 'val1'}, {id: 2, val: 'val2'}]);
   });
 
-  it('throws if there is no row', function () {
-    assert.throws(() => { docify(); });
+  it('returns null if there is no row', function () {
+    assert.equal(docify(), null);
   });
 });


### PR DESCRIPTION
A fix for an issue #451 