### PR TITLE
Upgrading pg-query-stream support

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,8 +48,8 @@
     "commander": "~2.11.0",
     "glob": "~7.1.1",
     "lodash": "~4.17.4",
-    "pg-promise": "~6.7.1",
-    "pg-query-stream": "~1.0.0"
+    "pg-promise": "~6.8.0",
+    "pg-query-stream": "~1.1.1"
   },
   "devDependencies": {
     "chai": "~4.1.0",


### PR DESCRIPTION
Use the very latest version of [pg-promise] that now requires the latest version of [pg-query-stream].

This is kind-of a breaking change for Massive.js, but only if you are using [pg-query-stream].

[pg-promise]:https://github.com/vitaly-t/pg-promise
[pg-query-stream]:https://github.com/brianc/node-pg-query-stream