### PR TITLE
pg-promise custom type formatting update

### DIFF
--- a/lib/loader/scripts.js
+++ b/lib/loader/scripts.js
@@ -28,7 +28,7 @@ exports = module.exports = (instance, config) => new Promise((resolve, reject) =
     loadedFiles.push(script.sql);
   }
 
-  const rawSQL = script.sql.toPostgres();
+  const rawSQL = script.sql[pgp.as.ctf.toPostgres]();
   const valuesMatch = rawSQL.match(patterns.multipleValues);
   const namesMatch = rawSQL.match(patterns.namedParameters);
 


### PR DESCRIPTION
This change will be needed, if you eventually get to upgrade `pg-promise` to [v7.1.0](https://github.com/vitaly-t/pg-promise/releases/tag/v.7.1.0) or later. That version brought it some changes that are non-breaking for any client, but for your integration this change will be needed.

So, do not accept this PR before you upgrade `pg-promise` to v7.1.0 or later! :wink: