### PR TITLE
fixed broken link to /documents

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -58,7 +58,7 @@ Results processing options are generally applicable to all query types, although
 | Option key | Description |
 |------------|-------------|
 | build      | Set to `true` to return the query text and parameters *without* executing anything. |
-| document   | Set to `true` to invoke [document table handling](/documents). |
+| document   | Set to `true` to invoke [document table handling](/massive-js/documents). |
 | single     | Set to `true` to return the first result as an object instead of a results array. |
 | stream     | Set to `true` to return results as a stream instead of an array. Streamed results cannot be `decompose`d. |
 | decompose  | Provide a schema to transform the results into an object graph (see below). Not compatible with `stream`. |


### PR DESCRIPTION
Link pointed to `/documents`, which is a 404

I'm not 100% positive, but I think the intended destination was https://dmfay.github.io/massive-js/documents, which might mean the link should point to `/massive-js/documents`