### PR TITLE
Fix timestamp casting for v4

### DIFF
--- a/docs/api/lib_statement_where.js.html
+++ b/docs/api/lib_statement_where.js.html
@@ -92,7 +92,7 @@ const docGenerator = function (condition, conditions) {
     } else if (_.isNumber(condition.value)) {
       cast = '::decimal';
     } else if (_.isDate(condition.value)) {
-      cast = '::timestamp';
+      cast = '::timestamptz';
       condition.params.push(condition.value);
       condition.value = `$${condition.offset}`;
     } else if (condition.appended.mutator) {

--- a/lib/statement/where.js
+++ b/lib/statement/where.js
@@ -64,7 +64,7 @@ const docGenerator = function (condition, conditions) {
     } else if (_.isNumber(condition.value)) {
       cast = '::decimal';
     } else if (_.isDate(condition.value)) {
-      cast = '::timestamp';
+      cast = '::timestamptz';
       condition.params.push(condition.value);
       condition.value = `$${condition.offset}`;
     } else if (condition.appended.mutator) {

--- a/test/helpers/scripts/data-docs/schema.sql
+++ b/test/helpers/scripts/data-docs/schema.sql
@@ -19,6 +19,6 @@ insert into uuid_docs(body) values ('{"things": "stuff"}');
 
 insert into docs(body)
 values('{"title":"Document 1","price":22,"description":"lorem ipsum etc","is_good":true,"created_at":"2015-03-04T09:43:41.643Z"}'),
-('{"title":"Document 2","price":18,"description":"Macaroni and Cheese","is_good":true,"created_at":"2015-03-04T09:43:41.643Z"}'),
-('{"title":"Document 3","price":18,"description":"something or other","is_good":true,"created_at":"2015-03-04T09:43:41.643Z"}'),
+('{"title":"Document 2","price":18,"description":"Macaroni and Cheese","is_good":true,"created_at":"2015-03-04T15:43:41.643+06:00"}'),
+('{"title":"Document 3","price":18,"description":"something or other","is_good":true,"created_at":"2015-03-04T06:43:41.643-03:00"}'),
 ('{"title":"Something Else","price":6,"description":"Two buddies fighting crime","is_good":false,"created_at":"1977-03-04T09:43:41.643Z","studios": [{"name" : "Warner"}, {"name" : "Universal"}]}');

--- a/test/queryable/findDoc.js
+++ b/test/queryable/findDoc.js
@@ -123,6 +123,12 @@ describe('findDoc', function () {
         assert.lengthOf(docs, 1);
       });
     });
+
+    it('works properly with timestamp including time zone', function () {
+      return db.docs.findDoc({'created_at >': new Date('2015-03-04T09:00:00.000Z')}).then(docs => {
+        assert.lengthOf(docs, 3);
+      });
+    });
   });
 
   describe('querying with options', function () {

--- a/test/statement/where.js
+++ b/test/statement/where.js
@@ -237,7 +237,7 @@ describe('WHERE clause generation', function () {
       const date = new Date();
       const condition = {rawField: 'field', appended: ops('<>'), value: date, offset: 1, params: []};
       const result = where.docGenerator(condition, {'field <>': date});
-      assert.equal(result.predicate, '("body" ->> \'field\')::timestamp <> $1');
+      assert.equal(result.predicate, '("body" ->> \'field\')::timestamptz <> $1');
       assert.equal(result.params.length, 1);
       assert.equal(result.params[0], date);
     });


### PR DESCRIPTION
This fixes bug #563. The same changes as PR #564 but for v4.

See below summary of changes:
* Change date casting from `timestamp` to `timestamptz`
* Add unit testing (for casting timestamp with timezone properly)