### PR TITLE
remove primary key requirement for loading tables

### DIFF
--- a/lib/scripts/tables.sql
+++ b/lib/scripts/tables.sql
@@ -14,7 +14,7 @@ SELECT * FROM (
   SELECT t.table_schema AS schema,
     t.table_name AS name,
     parent.relname AS parent,
-    array_agg(DISTINCT kc.column_name::text) AS pk,
+    array_agg(DISTINCT kc.column_name::text) FILTER (WHERE kc.column_name IS NOT NULL) AS pk,
     TRUE AS is_insertable_into,
     array_agg(DISTINCT c.column_name::text) AS columns
   FROM information_schema.tables t

--- a/lib/table.js
+++ b/lib/table.js
@@ -95,13 +95,17 @@ Table.prototype.insert = function (data, options) {
  */
 Table.prototype.update = function (criteria, fields, options = {}) {
   if (_.isNil(fields)) {
-    assert(!!this.pk, `${this.name} has no primary key, use update(criteria, changes)`);
+    if (!this.pk) {
+      return Promise.reject(new Error(`${this.name} has no primary key, use update(criteria, changes)`));
+    }
 
     fields = criteria;
 
     criteria = this.getPkCriteria(fields);
 
-    assert(!!criteria, `Incomplete or invalid primary key criteria for ${this.name}.update`);
+    if (!criteria) {
+      return Promise.reject(new Error(`Incomplete or invalid primary key criteria for ${this.name}.update`));
+    }
 
     fields = _.omitBy(fields, (value, key) => {
       return _.isFunction(fields[key]) || this.pk.indexOf(key) > -1;
@@ -110,7 +114,9 @@ Table.prototype.update = function (criteria, fields, options = {}) {
     options.single = true;
   }
 
-  assert(_.isObjectLike(fields) && !_.isArray(fields), 'Update requires a hash of fields=>values to update to');
+  if (!_.isObjectLike(fields) || _.isArray(fields)) {
+    return Promise.reject(new Error('Update requires a hash of fields=>values to update to'));
+  }
 
   if (_.isEmpty(fields)) {
     // there's nothing to update, so just return the matching records

--- a/lib/table.js
+++ b/lib/table.js
@@ -137,8 +137,11 @@ Table.prototype.update = function (criteria, fields, options = {}) {
  * @return {Promise} The inserted or updated record object.
  */
 Table.prototype.save = function (record, options = {}) {
-  assert(!!this.pk, `${this.name} has no primary key, use insert or update to write to this table`);
-  assert(_.isObjectLike(record) && !_.isArray(record), 'Must provide an object with all fields being modified and the primary key if updating');
+  if (!this.pk) {
+    return Promise.reject(new Error(`${this.name} has no primary key, use insert or update to write to this table`));
+  } else if (!_.isObjectLike(record) || _.isArray(record)) {
+    return Promise.reject(new Error('Must provide an object with all fields being modified and the primary key if updating'));
+  }
 
   const keys = _.keys(record);
 

--- a/lib/table.js
+++ b/lib/table.js
@@ -96,6 +96,10 @@ Table.prototype.insert = function (data, options) {
 Table.prototype.update = function (criteria, fields, options = {}) {
   if (_.isNil(fields)) {
     if (!this.pk) {
+      if (!this.is_insertable_into) {
+        return Promise.reject(new Error(`${this.name} is not writable`));
+      }
+
       return Promise.reject(new Error(`${this.name} has no primary key, use update(criteria, changes)`));
     }
 
@@ -144,6 +148,10 @@ Table.prototype.update = function (criteria, fields, options = {}) {
  */
 Table.prototype.save = function (record, options = {}) {
   if (!this.pk) {
+    if (!this.is_insertable_into) {
+      return Promise.reject(new Error(`${this.name} is not writable`));
+    }
+
     return Promise.reject(new Error(`${this.name} has no primary key, use insert or update to write to this table`));
   } else if (!_.isObjectLike(record) || _.isArray(record)) {
     return Promise.reject(new Error('Must provide an object with all fields being modified and the primary key if updating'));

--- a/test/connect.js
+++ b/test/connect.js
@@ -143,7 +143,7 @@ describe('connecting', function () {
 
     it('loads all tables', function () {
       return massive({connectionString}, loader).then(db => {
-        assert.lengthOf(db.objects.filter(o => o instanceof Table), 6);
+        assert.lengthOf(db.objects.filter(o => o instanceof Table), 7);
 
         return db.instance.$pool.end();
       });
@@ -179,15 +179,15 @@ describe('connecting', function () {
 
       return massive(connectionString, testLoader).then(db => {
         assert.isOk(db);
-        assert(!!db.t1 && !!db.t2 && !!db.tA);
+        assert(!!db.t1 && !!db.t2 && !!db.t3 && !!db.tA);
         assert(!!db.v1 && !!db.v2);
         assert(!!db.mv1 && !!db.mv2);
         assert(!!db.f1 && !!db.f2);
         assert(!!db.one && !!db.one.t1 && !!db.one.t2 && !!db.one.v1 && !!db.one.v2 && !!db.one.f1 && !!db.one.f2);
         assert(!!db.two && !!db.two.t1);
-        assert.lengthOf(db.objects, 17);
-        assert.lengthOf(db.objects.filter(o => o instanceof Queryable), 12);
-        assert.lengthOf(db.objects.filter(o => o instanceof Table), 6);
+        assert.lengthOf(db.objects, 18);
+        assert.lengthOf(db.objects.filter(o => o instanceof Queryable), 13);
+        assert.lengthOf(db.objects.filter(o => o instanceof Table), 7);
         assert.lengthOf(db.objects.filter(o => o instanceof Executable), 5);
         assert.lengthOf(db.objects.filter(o => o instanceof Executable && o.sql instanceof pgp.QueryFile), 1);
 
@@ -204,25 +204,17 @@ describe('connecting', function () {
 
       return massive(connectionString, testLoader).then(db => {
         assert.isOk(db);
-        assert(!!db.t1 && !!db.t2 && !!db.tA);
+        assert(!!db.t1 && !!db.t2 && !!db.t3 && !!db.tA);
         assert(!!db.v1 && !!db.v2);
         assert(!db.mv1 && !db.mv2);
         assert(!!db.f1 && !!db.f2);
         assert(!!db.one && !!db.one.t1 && !!db.one.t2 && !!db.one.v1 && !!db.one.v2 && !!db.one.f1 && !!db.one.f2);
         assert(!!db.two && !!db.two.t1);
-        assert.lengthOf(db.objects, 15);
-        assert.lengthOf(db.objects.filter(o => o instanceof Queryable), 10);
-        assert.lengthOf(db.objects.filter(o => o instanceof Table), 6);
+        assert.lengthOf(db.objects, 16);
+        assert.lengthOf(db.objects.filter(o => o instanceof Queryable), 11);
+        assert.lengthOf(db.objects.filter(o => o instanceof Table), 7);
         assert.lengthOf(db.objects.filter(o => o instanceof Executable), 5);
         assert.lengthOf(db.objects.filter(o => o instanceof Executable && o.sql instanceof pgp.QueryFile), 1);
-
-        return db.instance.$pool.end();
-      });
-    });
-
-    it('does not load tables without primary keys', function () {
-      return massive(connectionString, loader).then(db => {
-        assert(!db.t3); // tables without primary keys aren't loaded
 
         return db.instance.$pool.end();
       });
@@ -239,7 +231,7 @@ describe('connecting', function () {
 
       return massive(connectionString, testLoader).then(db => {
         assert(db);
-        assert(!db.t1 && !db.t2 && !db.tA);
+        assert(!db.t1 && !db.t2 && !db.t3 && !db.tA);
         assert(!db.v1 && !db.v2);
         assert(!db.mv1 && !db.mv2);
         assert(!db.f1 && !db.f2);
@@ -265,7 +257,7 @@ describe('connecting', function () {
 
       return massive(connectionString, testLoader).then(db => {
         assert(db);
-        assert(!!db.t1 && !db.t2 && !db.tA);
+        assert(!!db.t1 && !db.t2 && !db.t3 && !db.tA);
         assert(!!db.v1 && !db.v2);
         assert(!db.mv1 && !db.mv2);
         assert(!db.f1 && !db.f2);
@@ -292,15 +284,15 @@ describe('connecting', function () {
 
       return massive(connectionString, testLoader).then(db => {
         assert(db);
-        assert(!db.t1 && !!db.t2 && !!db.tA);
+        assert(!db.t1 && !!db.t2 && !!db.t3 && !!db.tA);
         assert(!db.v1 && !!db.v2);
         assert(!db.mv1 && !!db.mv2);
         assert(!!db.f1 && !!db.f2);
         assert(!!db.one && !db.one.t1 && !db.one.t2 && !db.one.v1 && !db.one.v2 && !!db.one.f1 && !!db.one.f2);
         assert(!db.two);
-        assert.lengthOf(db.objects, 9);
-        assert.lengthOf(db.objects.filter(o => o instanceof Queryable), 4);
-        assert.lengthOf(db.objects.filter(o => o instanceof Table), 2);
+        assert.lengthOf(db.objects, 10);
+        assert.lengthOf(db.objects.filter(o => o instanceof Queryable), 5);
+        assert.lengthOf(db.objects.filter(o => o instanceof Table), 3);
         assert.lengthOf(db.objects.filter(o => o instanceof Executable), 5);
         assert.lengthOf(db.objects.filter(o => o instanceof Executable && o.sql instanceof pgp.QueryFile), 1);
 
@@ -317,15 +309,15 @@ describe('connecting', function () {
 
       return massive(connectionString, testLoader).then(db => {
         assert(db);
-        assert(!!db.t1 && !!db.t2 && !!db.tA);
+        assert(!!db.t1 && !!db.t2 && !!db.t3 && !!db.tA);
         assert(!!db.v1 && !!db.v2);
         assert(!!db.mv1 && !!db.mv2);
         assert(!!db.f1 && !!db.f2);
         assert(!!db.one && !db.one.t1 && !!db.one.t2 && !db.one.v1 && !!db.one.v2 && !!db.one.f1 && !!db.one.f2);
         assert(!!db.two && !!db.two.t1);
-        assert.lengthOf(db.objects, 15);
-        assert.lengthOf(db.objects.filter(o => o instanceof Queryable), 10);
-        assert.lengthOf(db.objects.filter(o => o instanceof Table), 5);
+        assert.lengthOf(db.objects, 16);
+        assert.lengthOf(db.objects.filter(o => o instanceof Queryable), 11);
+        assert.lengthOf(db.objects.filter(o => o instanceof Table), 6);
         assert.lengthOf(db.objects.filter(o => o instanceof Executable), 5);
         assert.lengthOf(db.objects.filter(o => o instanceof Executable && o.sql instanceof pgp.QueryFile), 1);
 
@@ -343,15 +335,15 @@ describe('connecting', function () {
 
       return massive(connectionString, testLoader).then(db => {
         assert(db);
-        assert(!db.t1 && !!db.t2 && !!db.tA);
+        assert(!db.t1 && !!db.t2 && !!db.t3 && !!db.tA);
         assert(!db.v1 && !!db.v2);
         assert(!db.mv1 && !!db.mv2);
         assert(!!db.f1 && !!db.f2);
         assert(!!db.one && !!db.one.t1 && !!db.one.t2 && !!db.one.v1 && !!db.one.v2 && !!db.one.f1 && !!db.one.f2);
         assert(!db.two);
-        assert.lengthOf(db.objects, 13);
-        assert.lengthOf(db.objects.filter(o => o instanceof Queryable), 8);
-        assert.lengthOf(db.objects.filter(o => o instanceof Table), 4);
+        assert.lengthOf(db.objects, 14);
+        assert.lengthOf(db.objects.filter(o => o instanceof Queryable), 9);
+        assert.lengthOf(db.objects.filter(o => o instanceof Table), 5);
         assert.lengthOf(db.objects.filter(o => o instanceof Executable), 5);
         assert.lengthOf(db.objects.filter(o => o instanceof Executable && o.sql instanceof pgp.QueryFile), 1);
 

--- a/test/database/lists.js
+++ b/test/database/lists.js
@@ -13,7 +13,7 @@ describe('list functions', function () {
 
   describe('listTables', function () {
     it('lists tables', function () {
-      assert.sameMembers(db.listTables(), ['t1', 't2', 'tA', 'one.t1', 'one.t2', 'two.t1']);
+      assert.sameMembers(db.listTables(), ['t1', 't2', 't3', 'tA', 'one.t1', 'one.t2', 'two.t1']);
     });
   });
 

--- a/test/helpers/scripts/updatables/schema.sql
+++ b/test/helpers/scripts/updatables/schema.sql
@@ -1,0 +1,23 @@
+CREATE SCHEMA public;
+
+CREATE TABLE normal_pk (
+  id SERIAL NOT NULL PRIMARY KEY,
+  field1 TEXT
+);
+
+CREATE TABLE compound_pk (
+  id1 SERIAL NOT NULL,
+  id2 SERIAL NOT NULL,
+  field1 TEXT
+);
+
+ALTER TABLE compound_pk ADD PRIMARY KEY (id1, id2);
+
+CREATE TABLE no_pk (
+  field1 TEXT,
+  field2 TEXT
+);
+
+INSERT INTO normal_pk (field1) VALUES ('alpha'), ('beta'), ('gamma');
+INSERT INTO compound_pk (field1) VALUES ('alpha'), ('beta'), ('gamma');
+INSERT INTO no_pk (field1, field2) VALUES ('alpha', 'beta'), ('gamma', 'delta'), ('epsilon', 'zeta');

--- a/test/helpers/scripts/updatables/schema.sql
+++ b/test/helpers/scripts/updatables/schema.sql
@@ -2,7 +2,8 @@ CREATE SCHEMA public;
 
 CREATE TABLE normal_pk (
   id SERIAL NOT NULL PRIMARY KEY,
-  field1 TEXT
+  field1 TEXT,
+  array_field TEXT[]
 );
 
 CREATE TABLE compound_pk (
@@ -18,6 +19,12 @@ CREATE TABLE no_pk (
   field2 TEXT
 );
 
+CREATE TABLE "CasedName" (
+  "Id" SERIAL NOT NULL PRIMARY KEY,
+  "Field1" TEXT
+);
+
 INSERT INTO normal_pk (field1) VALUES ('alpha'), ('beta'), ('gamma');
 INSERT INTO compound_pk (field1) VALUES ('alpha'), ('beta'), ('gamma');
 INSERT INTO no_pk (field1, field2) VALUES ('alpha', 'beta'), ('gamma', 'delta'), ('epsilon', 'zeta');
+INSERT INTO "CasedName" ("Field1") VALUES ('Alpha'), ('Beta'), ('Gamma');

--- a/test/loader/tables.js
+++ b/test/loader/tables.js
@@ -18,7 +18,7 @@ describe('tables', function () {
     const tables = yield loader(db, config);
 
     assert.isArray(tables);
-    assert.lengthOf(tables, 3);
+    assert.lengthOf(tables, 4);
     assert.isTrue(tables[0].hasOwnProperty('schema'));
     assert.isTrue(tables[0].hasOwnProperty('name'));
     assert.isTrue(tables[0].hasOwnProperty('parent'));

--- a/test/loader/tables.js
+++ b/test/loader/tables.js
@@ -6,7 +6,7 @@ describe('tables', function () {
   let db;
 
   before(function* () {
-    db = yield resetDb('singletable');
+    db = yield resetDb('updatables');
   });
 
   after(function () {
@@ -18,10 +18,20 @@ describe('tables', function () {
     const tables = yield loader(db, config);
 
     assert.isArray(tables);
-    assert.lengthOf(tables, 1);
+    assert.lengthOf(tables, 3);
     assert.isTrue(tables[0].hasOwnProperty('schema'));
     assert.isTrue(tables[0].hasOwnProperty('name'));
     assert.isTrue(tables[0].hasOwnProperty('parent'));
     assert.isTrue(tables[0].hasOwnProperty('pk'));
+  });
+
+  it('should ignore null keys in the pk property', function* () {
+    const config = _.defaults({whitelist: 'no_pk'}, db.loader);
+    const tables = yield loader(db, config);
+
+    assert.lengthOf(tables, 1);
+
+    assert.equal(tables[0].name, 'no_pk');
+    assert.isNull(tables[0].pk);
   });
 });

--- a/test/table/foreign-tables.js
+++ b/test/table/foreign-tables.js
@@ -29,11 +29,19 @@ describe('foreign tables', function () {
   });
 
   it('cannot save to foreign tables', function () {
-    assert.throws(() => db.foreigntable.save({id: 1}), 'foreigntable has no primary key, use insert or update to write to this table');
+    db.foreigntable.save({id: 1})
+      .then(() => { assert.fail(); })
+      .catch(err => {
+        assert.equal(err.message, 'foreigntable has no primary key, use insert or update to write to this table');
+      });
   });
 
   it('cannot use the single-object update with foreign tables', function () {
-    assert.throws(() => db.foreigntable.update({id: 1}), 'foreigntable has no primary key, use update(criteria, changes)');
+    db.foreigntable.update({id: 1})
+      .then(() => { assert.fail(); })
+      .catch(err => {
+        assert.equal(err.message, 'foreigntable has no primary key, use update(criteria, changes)');
+      });
   });
 });
 

--- a/test/table/foreign-tables.js
+++ b/test/table/foreign-tables.js
@@ -29,15 +29,25 @@ describe('foreign tables', function () {
   });
 
   it('cannot save to foreign tables', function () {
-    db.foreigntable.save({id: 1})
+    return db.foreigntable.save({id: 1})
       .then(() => { assert.fail(); })
       .catch(err => {
-        assert.equal(err.message, 'foreigntable has no primary key, use insert or update to write to this table');
+        assert.equal(err.message, 'foreigntable is not writable');
+      });
+  });
+
+  it('cannot directly update foreign tables', function () {
+    return db.foreigntable.update({id: 1})
+      .then(() => { assert.fail(); })
+      .catch(err => {
+        assert.equal(err.message, 'foreigntable is not writable');
       });
   });
 
   it('cannot use the single-object update with foreign tables', function () {
-    db.foreigntable.update({id: 1})
+    db.foreigntable.is_insertable_into = true; // spoof a writable table to get around the check
+
+    return db.foreigntable.update({id: 1})
       .then(() => { assert.fail(); })
       .catch(err => {
         assert.equal(err.message, 'foreigntable has no primary key, use update(criteria, changes)');

--- a/test/table/inheritance.js
+++ b/test/table/inheritance.js
@@ -11,10 +11,10 @@ describe('Table Inheritance', function () {
     return db.instance.$pool.end();
   });
 
-  it('only loads descendant tables with primary keys', function () {
+  it('loads descendent tables', function () {
     assert.isOk(db.cities);
     assert.isOk(db.capitals);
-    assert.notOk(db.ancient);
+    assert.isOk(db.ancient);
   });
 
   describe('Querying', function () {

--- a/test/table/update.js
+++ b/test/table/update.js
@@ -4,7 +4,7 @@ describe('update', function () {
   let db;
 
   before(function () {
-    return resetDb().then(instance => db = instance);
+    return resetDb('updatables').then(instance => db = instance);
   });
 
   after(function () {
@@ -13,114 +13,112 @@ describe('update', function () {
 
   describe('single-object updates', function () {
     it('returns null when updating a nonexistent record', function () {
-      return db.products.update({id: 99999, name: 'new and improved product 4'}).then(res => {
+      return db.normal_pk.update({id: 99999, field1: 'something'}).then(res => {
         assert.isNull(res);
       });
     });
 
     it('throws when updating a record with operations in the pk field', function () {
-      assert.throws(() => {
-        db.products.update({'id <': 123, name: 'use other form for bulk updates'});
-      });
+      return db.normal_pk.update({
+        'id <': 123,
+        field1: 'something'
+      })
+        .then(() => { assert.fail(); })
+        .catch(err => {
+          assert.isOk(err);
+        });
     });
 
     it('updates a product by the primary key of a single record', function () {
-      return db.products.update({id: 4, name: 'new and improved product 4'}).then(res => {
-        assert.equal(res.id, 4);
-        assert.equal(res.name, 'new and improved product 4');
+      return db.normal_pk.update({id: 2, field1: 'something'}).then(res => {
+        assert.equal(res.id, 2);
+        assert.equal(res.field1, 'something');
       });
     });
 
     it('returns a product when there are no fields to be updated', function () {
-      return db.products.update({id: 1}).then(res => {
+      return db.normal_pk.update({id: 1}).then(res => {
         assert.equal(res.id, 1);
-        assert.equal(res.name, 'Product 1');
+        assert.equal(res.field1, 'alpha');
+      });
+    });
+
+    it('updates an array field', function () {
+      return db.normal_pk.update({id: 1, array_field: ['one', 'two']}).then(res => {
+        assert.equal(res.id, 1);
+        assert.lengthOf(res.array_field, 2);
+        assert.deepEqual(res.array_field, ['one', 'two']);
       });
     });
 
     it('updates an empty array field', function () {
-      return db.products.update({id: 1, tags: []}).then(res => {
+      return db.normal_pk.update({id: 1, array_field: []}).then(res => {
         assert.equal(res.id, 1);
-        assert.lengthOf(res.tags, 0);
+        assert.lengthOf(res.array_field, 0);
       });
     });
 
     it('updates a record in a table with a Cased Name', function () {
-      return db.Users.update({Id: 1, Email: 'bar@foo.com'}).then(res => {
+      return db.CasedName.update({Id: 1, Field1: 'Omega'}).then(res => {
         assert.equal(res.Id, 1);
-        assert.equal(res.Email, 'bar@foo.com');
+        assert.equal(res.Field1, 'Omega');
       });
     });
 
     it('applies options', function () {
-      return db.products.update({id: 1, name: 'another kind of product'}, null, {build: true}).then(res => {
+      return db.normal_pk.update({id: 1, field1: 'omega'}, null, {build: true}).then(res => {
         assert.deepEqual(res, {
-          sql: 'UPDATE "products" SET "name" = $1 WHERE "id" = $2 RETURNING *',
-          params: ['another kind of product', 1]
+          sql: 'UPDATE "normal_pk" SET "field1" = $1 WHERE "id" = $2 RETURNING *',
+          params: ['omega', 1]
         });
       });
     });
   });
 
   describe('bulk updates', function () {
-    it('updates multiple products', function () {
-      return db.products.update({in_stock: true}, {in_stock: false}).then(res => {
-        assert.equal(res.length, 2);
-        assert.notEqual(res[0].id, res[1].id);
-        assert.isFalse(res[0].in_stock);
-        assert.isFalse(res[1].in_stock);
+    it('updates multiple normal_pk', function () {
+      return db.normal_pk.update({'id >': 2}, {field1: 'zeta'}).then(res => {
+        assert.equal(res.length, 1);
+        assert.equal(res[0].id, 3);
+        assert.equal(res[0].field1, 'zeta');
       });
     });
 
-    it('updates all products', function () {
-      return db.products.update({}, {price: 1.23}).then(res => {
-        assert.equal(res.length, 4);
-        assert.equal(res[0].price, 1.23);
-        assert.equal(res[1].price, 1.23);
-        assert.equal(res[2].price, 1.23);
-        assert.equal(res[3].price, 1.23);
-      });
-    });
-
-    it('updates products with predicates of varying length', function () {
-      return db.products.update({'specs !=': null}, {price: 1.23}).then(res => {
+    it('updates all normal_pk', function () {
+      return db.normal_pk.update({}, {field1: 'upsilon'}).then(res => {
         assert.equal(res.length, 3);
-        assert.equal(res[0].price, 1.23);
-        assert.equal(res[1].price, 1.23);
-        assert.equal(res[2].price, 1.23);
+        assert.isTrue(res.every(r => r.field1 === 'upsilon'));
       });
     });
 
-    it('updates multiple products with an IN list', function () {
-      return db.products.update({id: [1, 2]}, {price: 123.45}).then(res => {
+    it('updates multiple normal_pk with an IN list', function () {
+      return db.normal_pk.update({id: [1, 2]}, {field1: 'theta'}).then(res => {
         assert.equal(res.length, 2);
         assert.notEqual(res[0].id, res[1].id);
-        assert.equal(res[0].price, 123.45);
-        assert.equal(res[1].price, 123.45);
+        assert.isTrue(res.every(r => r.field1 === 'theta'));
       });
     });
 
-    it('updates multiple products with a NOT IN list', function () {
-      return db.products.update({'id !=': [1, 2]}, {price: 543.21}).then(res => {
-        assert.equal(res.length, 2);
-        assert.notEqual(res[0].id, res[1].id);
-        assert.equal(res[0].price, 543.21);
-        assert.equal(res[1].price, 543.21);
+    it('updates multiple normal_pk with a NOT IN list', function () {
+      return db.normal_pk.update({'id !=': [1, 2]}, {field1: 'tau'}).then(res => {
+        assert.equal(res.length, 1);
+        assert.equal(res[0].id, 3);
+        assert.equal(res[0].field1, 'tau');
       });
     });
 
-    it('returns multiple products when there are no fields to be updated', function () {
-      return db.products.update({id: [1, 2]}, {}).then(res => {
-        assert.equal(res[0].id, 1);
-        assert.equal(res[0].name, 'Product 1');
+    it('returns multiple normal_pk when there are no fields to be updated', function () {
+      return db.normal_pk.update({id: [1, 2]}, {}).then(res => {
+        assert.isTrue(res.some(r => r.id === 1));
+        assert.isTrue(res.some(r => r.id === 2));
       });
     });
 
     it('applies options', function () {
-      return db.products.update({id: [1, 2]}, {name: 'another kind of product'}, {build: true}).then(res => {
+      return db.normal_pk.update({id: [1, 2]}, {field1: 'iota'}, {build: true}).then(res => {
         assert.deepEqual(res, {
-          sql: 'UPDATE "products" SET "name" = $1 WHERE "id" IN ($2,$3) RETURNING *',
-          params: ['another kind of product', 1, 2]
+          sql: 'UPDATE "normal_pk" SET "field1" = $1 WHERE "id" IN ($2,$3) RETURNING *',
+          params: ['iota', 1, 2]
         });
       });
     });


### PR DESCRIPTION
This seems to trip people up a lot, and between the connecting user and blacklists/whitelists we already have two things that affect what actually gets loaded. Plus, better error messaging.