### PR TITLE
Fix has own property issue for v4

### DIFF
--- a/lib/executable.js
+++ b/lib/executable.js
@@ -32,7 +32,7 @@ const Executable = function (spec) {
   Entity.apply(this, arguments);
 
   this.sql = spec.sql;
-  this.isDatabaseFunction = spec.hasOwnProperty('isVariadic');
+  this.isDatabaseFunction = Object.prototype.hasOwnProperty.call(spec, 'isVariadic');
   this.paramCount = spec.paramCount;  // this actually only matters for QueryFiles since functions can have overloads
   this.isVariadic = !!spec.isVariadic;  // only for db functions
   this.singleRow = spec.enhancedFunctions && spec.singleRow;

--- a/lib/queryable.js
+++ b/lib/queryable.js
@@ -126,7 +126,7 @@ Queryable.prototype.isPkSearch = function (criteria) {
     const criteriaKeys = Object.keys(criteria);
 
     return this.pk.every(keyColumn => {
-      if (criteria.hasOwnProperty(keyColumn)) { return true; }
+      if (Object.prototype.hasOwnProperty.call(criteria, keyColumn)) { return true; }
 
       return criteriaKeys.some(k => new RegExp(`^${keyColumn}[^\\w\\d]?`).test(k));
     });

--- a/lib/statement/insert.js
+++ b/lib/statement/insert.js
@@ -21,7 +21,7 @@ const Insert = function (source, record, options = {}) {
   this.generator = options.generator;
   this.stream = options.stream;
   this.onConflictIgnore = options.onConflictIgnore;
-  this.deepInsert = options.hasOwnProperty('deepInsert') ? options.deepInsert : true;
+  this.deepInsert = Object.prototype.hasOwnProperty.call(options, 'deepInsert') ? options.deepInsert : true;
   if (_.isArray(record)) {
     this.records = record;
   } else {

--- a/lib/statement/select.js
+++ b/lib/statement/select.js
@@ -63,7 +63,7 @@ const Select = function (source, criteria = {}, options = {}) {
     this.fields = ['*'];
   }
 
-  if (criteria.hasOwnProperty('conditions') && criteria.hasOwnProperty('params')) {
+  if (Object.prototype.hasOwnProperty.call(criteria, 'conditions') && Object.prototype.hasOwnProperty.call(criteria, 'params')) {
     // pre-built predicates (full-text searches and Queryable.where style calls use this)
     this.where = criteria;
   } else if (source.isPkSearch(criteria)) {

--- a/lib/table.js
+++ b/lib/table.js
@@ -44,7 +44,7 @@ Table.prototype.getPkCriteria = function (record) {
   let missing = false;
 
   const criteria = this.pk.reduce((obj, pkColumn) => {
-    if (record.hasOwnProperty(pkColumn)) {
+    if (Object.prototype.hasOwnProperty.call(record, pkColumn)) {
       obj[pkColumn] = record[pkColumn];
     } else {
       missing = true;

--- a/lib/util/decompose.js
+++ b/lib/util/decompose.js
@@ -56,7 +56,7 @@ exports = module.exports = function (schema, data) {
       if (id === null) {
         // null id means this entity doesn't exist (eg outer join)
         return undefined;
-      } else if (!obj.hasOwnProperty(strid)) {
+      } else if (!Object.prototype.hasOwnProperty.call(obj, strid)) {
         // this entity is new
         obj[strid] = {};
       }

--- a/test/queryable/findDoc.js
+++ b/test/queryable/findDoc.js
@@ -153,6 +153,17 @@ describe('findDoc', function () {
       });
     });
 
+    it('passing object without hasOwnProperty method', function () {
+      const criteria = Object.create(null);
+      criteria.title = 'Document 1';
+      return db.docs.findDoc(criteria).then(docs => {
+        assert.lengthOf(docs, 1);
+        assert.equal(docs[0].id, 1);
+        assert.equal(docs[0].title, 'Document 1');
+        assert.equal(docs[0].description, 'lorem ipsum etc');
+      });
+    });
+
     it('applies offset and limit with a fixed sort by pk', function () {
       return db.docs.findDoc('*', {offset: 1, limit: 1}).then(docs => {
         assert.lengthOf(docs, 1);


### PR DESCRIPTION
This fixes bug #579 .

See below summary of changes:
* Use `hasOwnProperty` from Object prototype
* Add unit testing (by creating object with `Object.create(null)`)