### PR TITLE
Added special key for nested conjunctions

### DIFF
--- a/lib/statement/where.js
+++ b/lib/statement/where.js
@@ -127,6 +127,35 @@ const generateDisjunction = (conditions, offset, generator) => {
 };
 
 /**
+ * Build an inner conjunction (logical OR).
+ *
+ * @param {Array} conditions - An array of nested criteria objects. Individual
+ * objects will be arrayified (so an 'and' key can work with a single object).
+ * @param {Number} offset - Offset prepared statement parameter ordinals.
+ * @param {Function} generator - Generator function to use to build SQL
+ * predicates.
+ * @return {Object} A nested conjunction node.
+ */
+const generateInnerConjunction = (conditions, offset, generator) => {
+  return _.reduce(conditions, (conjunction, subconditions) => {
+    // each member of an 'and' array is itself a conjunction, so build it and
+    // integrate it into the conjunction predicate structure
+    /* eslint-disable no-use-before-define */
+    const innerConjunction = generateConjunction(subconditions, conjunction.offset + conjunction.params.length, generator);
+    /* eslint-enable no-use-before-define */
+
+    conjunction.params = conjunction.params.concat(innerConjunction.params);
+    conjunction.predicates.push(`(${innerConjunction.predicates.join(' AND ')})`);
+
+    return conjunction;
+  }, {
+    params: [],
+    predicates: [],
+    offset
+  });
+};
+
+/**
  * Build a conjunction (logical AND).
  *
  * @param {Object} conditions - A criteria object.
@@ -142,6 +171,13 @@ const generateConjunction = (conditions, offset, generator) => {
 
       conjunction.params = conjunction.params.concat(disjunction.params);
       conjunction.predicates.push(`(${disjunction.predicates.join(' OR ')})`);
+
+      return conjunction;
+    } else if (key === 'and') {
+      const inner_conjunction = generateInnerConjunction(value, conjunction.offset + conjunction.params.length, generator);
+
+      conjunction.params = conjunction.params.concat(inner_conjunction.params);
+      conjunction.predicates.push(`(${inner_conjunction.predicates.join(' AND ')})`);
 
       return conjunction;
     }

--- a/test/statement/where.js
+++ b/test/statement/where.js
@@ -151,6 +151,25 @@ describe('WHERE clause generation', function () {
         assert.equal(result.params[3], 'value4');
       });
 
+      it("should encapsulate and AND together 'and' subgroups", function () {
+        const result = where({
+          and: [{
+            field1: 'value1'
+          }, {
+            field2: 'value2', field3: 'value3'
+          }, {
+            field4: 'value4'
+          }]
+        });
+
+        assert.equal(result.conditions, '(("field1" = $1) AND ("field2" = $2 AND "field3" = $3) AND ("field4" = $4))');
+        assert.equal(result.params.length, 4);
+        assert.equal(result.params[0], 'value1');
+        assert.equal(result.params[1], 'value2');
+        assert.equal(result.params[2], 'value3');
+        assert.equal(result.params[3], 'value4');
+      });
+
       it('should not pollute other fields', function () {
         const result = where({
           or: [{field1: 'value1'}, {field2: 'value2'}],

--- a/test/statement/where.js
+++ b/test/statement/where.js
@@ -131,7 +131,7 @@ describe('WHERE clause generation', function () {
       });
     });
 
-    describe('with subgroups', function () {
+    describe('with disjunction subgroups', function () {
       it('should encapsulate and OR together subgroups', function () {
         const result = where({
           or: [{
@@ -144,25 +144,6 @@ describe('WHERE clause generation', function () {
         });
 
         assert.equal(result.conditions, '(("field1" = $1) OR ("field2" = $2 AND "field3" = $3) OR ("field4" = $4))');
-        assert.equal(result.params.length, 4);
-        assert.equal(result.params[0], 'value1');
-        assert.equal(result.params[1], 'value2');
-        assert.equal(result.params[2], 'value3');
-        assert.equal(result.params[3], 'value4');
-      });
-
-      it('should encapsulate and AND together inner conjunction subgroups', function () {
-        const result = where({
-          and: [{
-            field1: 'value1'
-          }, {
-            field2: 'value2', field3: 'value3'
-          }, {
-            field4: 'value4'
-          }]
-        });
-
-        assert.equal(result.conditions, '(("field1" = $1) AND ("field2" = $2 AND "field3" = $3) AND ("field4" = $4))');
         assert.equal(result.params.length, 4);
         assert.equal(result.params[0], 'value1');
         assert.equal(result.params[1], 'value2');
@@ -207,6 +188,72 @@ describe('WHERE clause generation', function () {
         });
 
         assert.equal(result.conditions, '(("field1" = $1 AND (("field2" = $2) OR ("field3" = $3))) OR ("field2" = $4 AND "field3" = $5))');
+        assert.equal(result.params.length, 5);
+        assert.equal(result.params[0], 'value1');
+        assert.equal(result.params[1], 'value4');
+        assert.equal(result.params[2], 'value5');
+        assert.equal(result.params[3], 'value2');
+        assert.equal(result.params[4], 'value3');
+      });
+    });
+
+    describe('with nested conjunction subgroups', function () {
+      it('should encapsulate and AND together subgroups', function () {
+        const result = where({
+          and: [{
+            field1: 'value1'
+          }, {
+            field2: 'value2', field3: 'value3'
+          }, {
+            field4: 'value4'
+          }]
+        });
+
+        assert.equal(result.conditions, '(("field1" = $1) AND ("field2" = $2 AND "field3" = $3) AND ("field4" = $4))');
+        assert.equal(result.params.length, 4);
+        assert.equal(result.params[0], 'value1');
+        assert.equal(result.params[1], 'value2');
+        assert.equal(result.params[2], 'value3');
+        assert.equal(result.params[3], 'value4');
+      });
+
+      it('should not pollute other fields', function () {
+        const result = where({
+          and: [{field1: 'value1'}, {field2: 'value2'}],
+          field3: 'value3'
+        });
+
+        assert.equal(result.conditions, '(("field1" = $1) AND ("field2" = $2)) AND "field3" = $3');
+        assert.equal(result.params.length, 3);
+        assert.equal(result.params[0], 'value1');
+        assert.equal(result.params[1], 'value2');
+        assert.equal(result.params[2], 'value3');
+      });
+
+      it('should return a usable predicate if only given one subgroup', function () {
+        const result = where({and: [{field1: 'value1'}]});
+
+        assert.equal(result.conditions, '(("field1" = $1))');
+        assert.equal(result.params.length, 1);
+        assert.equal(result.params[0], 'value1');
+      });
+
+      it('recurses', function () {
+        const result = where({
+          or: [{
+            field1: 'value1',
+            and: [{
+              field2: 'value4'
+            }, {
+              field3: 'value5'
+            }]
+          }, {
+            field2: 'value2',
+            field3: 'value3'
+          }]
+        });
+
+        assert.equal(result.conditions, '(("field1" = $1 AND (("field2" = $2) AND ("field3" = $3))) OR ("field2" = $4 AND "field3" = $5))');
         assert.equal(result.params.length, 5);
         assert.equal(result.params[0], 'value1');
         assert.equal(result.params[1], 'value4');

--- a/test/statement/where.js
+++ b/test/statement/where.js
@@ -151,7 +151,7 @@ describe('WHERE clause generation', function () {
         assert.equal(result.params[3], 'value4');
       });
 
-      it("should encapsulate and AND together 'and' subgroups", function () {
+      it('should encapsulate and AND together inner conjunction subgroups', function () {
         const result = where({
           and: [{
             field1: 'value1'


### PR DESCRIPTION
Currently with Massive, it's impossible to refer to a single column multiple times in a criteria object, for example, to represent the clause: `where blah not like 'abc%' and blah not like 'def%'`. This change introduces a new "and" key in criteria, like the "or" key, that generates a nested conjunction clause (like how the "or" key generates a nested disjunction).