### PR TITLE
Timestamp casting

### DIFF
--- a/lib/statement/mutators.js
+++ b/lib/statement/mutators.js
@@ -12,7 +12,7 @@ const _ = require('lodash');
  */
 exports.buildBetween = condition => {
   condition.params = condition.value;
-  condition.value = `$${condition.offset}${castTimestamp(condition.params[condition.offset])} AND $${condition.offset+1}${castTimestamp(condition.params[condition.offset+1])}`;
+  condition.value = `$${condition.offset}${castTimestamp(condition.value[0])} AND $${condition.offset+1}${castTimestamp(condition.value[1])}`;
   condition.offset += 2
 
   return condition;

--- a/lib/statement/mutators.js
+++ b/lib/statement/mutators.js
@@ -4,6 +4,13 @@
 
 const _ = require('lodash');
 
+const castTimestamp = (value) => {
+  if(_.isDate(value)) {
+    return '::timestamptz';
+  }
+  return '';
+};
+
 /**
  * Build a BETWEEN (a, b) predicate.
  *
@@ -12,8 +19,8 @@ const _ = require('lodash');
  */
 exports.buildBetween = condition => {
   condition.params = condition.value;
-  condition.value = `$${condition.offset}${castTimestamp(condition.value[0])} AND $${condition.offset+1}${castTimestamp(condition.value[1])}`;
-  condition.offset += 2
+  condition.value = `$${condition.offset}${castTimestamp(condition.value[0])} AND $${condition.offset + 1}${castTimestamp(condition.value[1])}`;
+  condition.offset += 2;
 
   return condition;
 };
@@ -99,12 +106,4 @@ exports.literalizeArray = condition => {
   condition.value = `$${condition.offset}${castTimestamp(condition.value)}`;
 
   return condition;
-};
-
-const castTimestamp = (value) => {
-    if(_.isDate(value)) {
-        return '::timestamptz';
-    } else {
-        return '';
-    }
 };

--- a/lib/statement/mutators.js
+++ b/lib/statement/mutators.js
@@ -12,7 +12,8 @@ const _ = require('lodash');
  */
 exports.buildBetween = condition => {
   condition.params = condition.value;
-  condition.value = `$${condition.offset++} AND $${condition.offset++}`;
+  condition.value = `$${condition.offset}${castTimestamp(condition.params[condition.offset])} AND $${condition.offset+1}${castTimestamp(condition.params[condition.offset+1])}`;
+  condition.offset += 2
 
   return condition;
 };
@@ -29,7 +30,7 @@ exports.buildIn = condition => {
   const inList = _.reduce(condition.value, (list, v) => {
     condition.params.push(v);
 
-    return list.concat([`$${condition.offset++}`]);
+    return list.concat([`$${condition.offset++}${castTimestamp(v)}`]);
   }, []);
 
   condition.value = `(${inList.join(',')})`;
@@ -67,7 +68,7 @@ exports.equality = function (condition) {
 
   condition.params.push(condition.value);
 
-  condition.value = `$${condition.offset}`;
+  condition.value = `$${condition.offset}${castTimestamp(condition.value)}`;
 
   return condition;
 };
@@ -95,7 +96,15 @@ exports.literalizeArray = condition => {
     condition.params.push(condition.value);
   }
 
-  condition.value = `$${condition.offset}`;
+  condition.value = `$${condition.offset}${castTimestamp(condition.value)}`;
 
   return condition;
+};
+
+const castTimestamp = (value) => {
+    if(_.isDate(value)) {
+        return '::timestamptz';
+    } else {
+        return '';
+    }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -169,7 +169,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1817,8 +1816,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -2116,7 +2114,6 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
-      "optional": true,
       "requires": {
         "is-buffer": "^1.1.5"
       }
@@ -2232,8 +2229,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -2544,7 +2540,6 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -3487,8 +3482,7 @@
         "longest": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -5053,8 +5047,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "repeating": {
       "version": "2.0.1",

--- a/test/statement/mutators.js
+++ b/test/statement/mutators.js
@@ -24,7 +24,7 @@ describe('mutators', function () {
       const date2 = new Date();
       const condition = mutators.buildBetween({
         offset: 1,
-          value: [date1, date2],
+        value: [date1, date2],
         params: []
       });
 
@@ -237,7 +237,7 @@ describe('mutators', function () {
       });
     });
 
-    it("typecasts timestamps if it's not an array", function () {
+    it('typecasts timestamps if not in an array', function () {
       const date1 = new Date();
       const condition = {
         offset: 1,

--- a/test/statement/mutators.js
+++ b/test/statement/mutators.js
@@ -18,6 +18,22 @@ describe('mutators', function () {
         value: '$1 AND $2'
       });
     });
+
+    it('typecasts timestamps', function () {
+      const date1 = new Date();
+      const date2 = new Date();
+      const condition = mutators.buildBetween({
+        offset: 1,
+          value: [date1, date2],
+        params: []
+      });
+
+      assert.deepEqual(condition, {
+        offset: 3,
+        params: [date1, date2],
+        value: '$1::timestamptz AND $2::timestamptz'
+      });
+    });
   });
 
   describe('buildIn', function () {
@@ -47,6 +63,22 @@ describe('mutators', function () {
       assert.equal(condition.offset, 4);
       assert.deepEqual(condition.params, [1, 2, 3]);
       assert.equal(condition.value, '($1,$2,$3)');
+    });
+
+    it('typecasts timestamps', function () {
+      const date1 = new Date();
+      const date2 = new Date();
+      const condition = mutators.buildIn({
+        appended: ops('='),
+        offset: 1,
+        value: [date1, date2],
+        params: []
+      });
+
+      assert.equal(condition.appended.operator, 'IN');
+      assert.equal(condition.offset, 3);
+      assert.deepEqual(condition.params, [date1, date2]);
+      assert.equal(condition.value, '($1::timestamptz,$2::timestamptz)');
     });
   });
 
@@ -131,6 +163,21 @@ describe('mutators', function () {
       assert.deepEqual(condition.params, [123]);
       assert.equal(condition.value, '$1');
     });
+
+    it('typecasts timestamps', function () {
+      const date1 = new Date();
+      const condition = mutators.equality({
+        appended: ops('='),
+        offset: 1,
+        value: date1,
+        params: []
+      });
+
+      assert.equal(condition.appended.operator, '=');
+      assert.equal(condition.offset, 1);
+      assert.deepEqual(condition.params, [date1]);
+      assert.equal(condition.value, '$1::timestamptz');
+    });
   });
 
   describe('literalizeArray', function () {
@@ -187,6 +234,21 @@ describe('mutators', function () {
         offset: 1,
         params: ['{1,true,null,1.5}'],
         value: '$1'
+      });
+    });
+
+    it("typecasts timestamps if it's not an array", function () {
+      const date1 = new Date();
+      const condition = {
+        offset: 1,
+        value: date1,
+        params: []
+      };
+
+      assert.deepEqual(mutators.literalizeArray(condition), {
+        offset: 1,
+        params: [date1],
+        value: '$1::timestamptz'
       });
     });
   });


### PR DESCRIPTION
When you do something like this:

```connection.some_table.find({ whatever: new Date() })```

it needs to generate SQL like this:

```select * from some_table where whatever = $1::timestamptz```

or else Postgres blows up thinking that the date is a string.